### PR TITLE
feat: ensure an attachment is not committed before commit

### DIFF
--- a/applications/backend/core/src/main/kotlin/com/forsetijudge/core/application/helper/AttachmentWriterHelper.kt
+++ b/applications/backend/core/src/main/kotlin/com/forsetijudge/core/application/helper/AttachmentWriterHelper.kt
@@ -1,0 +1,41 @@
+package com.forsetijudge.core.application.helper
+
+import com.forsetijudge.core.application.util.SafeLogger
+import com.forsetijudge.core.domain.entity.Attachment
+import com.forsetijudge.core.domain.exception.ForbiddenException
+import com.forsetijudge.core.domain.exception.NotFoundException
+import com.forsetijudge.core.port.driven.repository.AttachmentRepository
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class AttachmentWriterHelper(
+    private val attachmentRepository: AttachmentRepository,
+) {
+    private val logger = SafeLogger(this::class)
+
+    fun commit(
+        attachmentId: UUID,
+        contestId: UUID,
+        context: Attachment.Context,
+    ): Attachment {
+        logger.info("Committing attachment with id: $attachmentId in contest with id: $contestId and context: $context")
+
+        val attachment =
+            attachmentRepository.findByIdAndContestId(attachmentId, contestId)
+                ?: throw NotFoundException("Attachment with id $attachmentId not found in contest with id $contestId")
+
+        if (attachment.isCommited) {
+            throw ForbiddenException("Attachment with id $attachmentId is already commited")
+        }
+        if (attachment.context != context) {
+            throw ForbiddenException("Attachment with id $attachmentId has invalid context ${attachment.context}")
+        }
+
+        attachment.isCommited = true
+
+        attachmentRepository.save(attachment)
+        logger.info("Attachment committed successfully")
+        return attachment
+    }
+}

--- a/applications/backend/core/src/main/kotlin/com/forsetijudge/core/application/service/external/contest/UpdateContestService.kt
+++ b/applications/backend/core/src/main/kotlin/com/forsetijudge/core/application/service/external/contest/UpdateContestService.kt
@@ -1,5 +1,6 @@
 package com.forsetijudge.core.application.service.external.contest
 
+import com.forsetijudge.core.application.helper.AttachmentWriterHelper
 import com.forsetijudge.core.application.util.ContestAuthorizer
 import com.forsetijudge.core.application.util.SafeLogger
 import com.forsetijudge.core.application.util.TestCasesValidator
@@ -32,13 +33,13 @@ import java.util.UUID
 @Service
 @Validated
 class UpdateContestService(
-    private val attachmentRepository: AttachmentRepository,
     private val contestRepository: ContestRepository,
     private val problemRepository: ProblemRepository,
     private val memberRepository: MemberRepository,
     private val hasher: Hasher,
     private val testCasesValidator: TestCasesValidator,
     private val publishOutboxEventInternalUseCase: PublishOutboxEventInternalUseCase,
+    private val attachmentWriterHelper: AttachmentWriterHelper,
 ) : UpdateContestUseCase {
     private val logger = SafeLogger(this::class)
 
@@ -177,22 +178,9 @@ class UpdateContestService(
     ): Problem {
         logger.info("Creating problem with title: ${problemDTO.title}")
 
-        val description =
-            attachmentRepository.findByIdAndContestId(problemDTO.description.id, contest.id)
-                ?: throw NotFoundException("Could not find description attachment with id: ${problemDTO.description.id} in this contest")
-        if (description.context != Attachment.Context.PROBLEM_DESCRIPTION) {
-            throw ForbiddenException("Attachment with id: ${description.id} is not a valid problem description")
-        }
-        description.isCommited = true
-
-        val testCases =
-            attachmentRepository.findByIdAndContestId(problemDTO.testCases.id, contest.id)
-                ?: throw NotFoundException("Could not find testCases attachment with id: ${problemDTO.testCases.id} in this contest")
-        if (testCases.context != Attachment.Context.PROBLEM_TEST_CASES) {
-            throw ForbiddenException("Attachment with id: ${testCases.id} is not a valid problem test cases")
-        }
+        val description = attachmentWriterHelper.commit(problemDTO.description.id, contest.id, Attachment.Context.PROBLEM_DESCRIPTION)
+        val testCases = attachmentWriterHelper.commit(problemDTO.testCases.id, contest.id, Attachment.Context.PROBLEM_TEST_CASES)
         testCasesValidator.validate(testCases)
-        testCases.isCommited = true
 
         val problem =
             Problem(
@@ -257,26 +245,12 @@ class UpdateContestService(
                 ?: throw NotFoundException("Could not find problem with id = ${problemDTO.id}")
 
         if (problem.description.id != problemDTO.description.id) {
-            val description =
-                attachmentRepository.findByIdAndContestId(problemDTO.description.id, contest.id)
-                    ?: throw NotFoundException(
-                        "Could not find description attachment with id: ${problemDTO.description.id} in this contest",
-                    )
-            if (description.context != Attachment.Context.PROBLEM_DESCRIPTION) {
-                throw ForbiddenException("Attachment with id: ${description.id} is not a valid problem description")
-            }
-            description.isCommited = true
+            val description = attachmentWriterHelper.commit(problemDTO.description.id, contest.id, Attachment.Context.PROBLEM_DESCRIPTION)
             problem.description = description
         }
         if (problem.testCases.id != problemDTO.testCases.id) {
-            val testCases =
-                attachmentRepository.findByIdAndContestId(problemDTO.testCases.id, contest.id)
-                    ?: throw NotFoundException("Could not find testCases attachment with id: ${problemDTO.testCases.id} in this contest")
-            if (testCases.context != Attachment.Context.PROBLEM_TEST_CASES) {
-                throw ForbiddenException("Attachment with id: ${testCases.id} is not a valid problem test cases")
-            }
+            val testCases = attachmentWriterHelper.commit(problemDTO.testCases.id, contest.id, Attachment.Context.PROBLEM_TEST_CASES)
             testCasesValidator.validate(testCases)
-            testCases.isCommited = true
             problem.testCases = testCases
         }
 

--- a/applications/backend/core/src/main/kotlin/com/forsetijudge/core/application/service/external/contest/UpdateContestService.kt
+++ b/applications/backend/core/src/main/kotlin/com/forsetijudge/core/application/service/external/contest/UpdateContestService.kt
@@ -15,7 +15,6 @@ import com.forsetijudge.core.domain.exception.ForbiddenException
 import com.forsetijudge.core.domain.exception.NotFoundException
 import com.forsetijudge.core.domain.model.ExecutionContext
 import com.forsetijudge.core.port.driven.cryptography.Hasher
-import com.forsetijudge.core.port.driven.repository.AttachmentRepository
 import com.forsetijudge.core.port.driven.repository.ContestRepository
 import com.forsetijudge.core.port.driven.repository.MemberRepository
 import com.forsetijudge.core.port.driven.repository.ProblemRepository

--- a/applications/backend/core/src/main/kotlin/com/forsetijudge/core/application/service/external/submission/CreateSubmissionService.kt
+++ b/applications/backend/core/src/main/kotlin/com/forsetijudge/core/application/service/external/submission/CreateSubmissionService.kt
@@ -1,5 +1,6 @@
 package com.forsetijudge.core.application.service.external.submission
 
+import com.forsetijudge.core.application.helper.AttachmentWriterHelper
 import com.forsetijudge.core.application.util.ContestAuthorizer
 import com.forsetijudge.core.application.util.SafeLogger
 import com.forsetijudge.core.domain.entity.Attachment
@@ -28,13 +29,13 @@ import org.springframework.validation.annotation.Validated
 @Service
 @Validated
 class CreateSubmissionService(
-    private val attachmentRepository: AttachmentRepository,
     private val contestRepository: ContestRepository,
     private val memberRepository: MemberRepository,
     private val problemRepository: ProblemRepository,
     private val submissionRepository: SubmissionRepository,
     private val frozenSubmissionRepository: FrozenSubmissionRepository,
     private val publishOutboxEventInternalUseCase: PublishOutboxEventInternalUseCase,
+    private val attachmentWriterHelper: AttachmentWriterHelper,
 ) : CreateSubmissionUseCase {
     private val logger = SafeLogger(this::class)
 
@@ -63,18 +64,16 @@ class CreateSubmissionService(
             problemRepository.findByIdAndContestId(command.problemId, contextContestId)
                 ?: throw NotFoundException("Could not find problem with id = ${command.problemId} in contest")
         val code =
-            attachmentRepository.findByIdAndContestId(command.code.id, contextContestId)
-                ?: throw NotFoundException("Could not find code attachment with id = ${command.code.id} in contest")
-
-        if (code.context != Attachment.Context.SUBMISSION_CODE) {
-            throw ForbiddenException("Attachment with id = ${command.code.id} is not a submission code")
-        }
+            attachmentWriterHelper.commit(
+                attachmentId = command.code.id,
+                contestId = contextContestId,
+                context = Attachment.Context.SUBMISSION_CODE,
+            )
 
         if (contest.languages.none { it == command.language }) {
             throw ForbiddenException("Language ${command.language} is not allowed for this contest")
         }
 
-        code.isCommited = true
         val submission =
             Submission(
                 member = member,

--- a/applications/backend/core/src/main/kotlin/com/forsetijudge/core/application/service/external/submission/CreateSubmissionService.kt
+++ b/applications/backend/core/src/main/kotlin/com/forsetijudge/core/application/service/external/submission/CreateSubmissionService.kt
@@ -11,7 +11,6 @@ import com.forsetijudge.core.domain.event.SubmissionEvent
 import com.forsetijudge.core.domain.exception.ForbiddenException
 import com.forsetijudge.core.domain.exception.NotFoundException
 import com.forsetijudge.core.domain.model.ExecutionContext
-import com.forsetijudge.core.port.driven.repository.AttachmentRepository
 import com.forsetijudge.core.port.driven.repository.ContestRepository
 import com.forsetijudge.core.port.driven.repository.FrozenSubmissionRepository
 import com.forsetijudge.core.port.driven.repository.MemberRepository

--- a/applications/backend/core/src/test/kotlin/com/forsetijudge/core/application/helper/AttachmentWriterHelperTest.kt
+++ b/applications/backend/core/src/test/kotlin/com/forsetijudge/core/application/helper/AttachmentWriterHelperTest.kt
@@ -1,0 +1,85 @@
+package com.forsetijudge.core.application.helper
+
+import com.forsetijudge.core.application.util.IdGenerator
+import com.forsetijudge.core.domain.entity.Attachment
+import com.forsetijudge.core.domain.entity.AttachmentMockBuilder
+import com.forsetijudge.core.domain.exception.ForbiddenException
+import com.forsetijudge.core.domain.exception.NotFoundException
+import com.forsetijudge.core.port.driven.repository.AttachmentRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class AttachmentWriterHelperTest :
+    FunSpec({
+        val attachmentRepository = mockk<AttachmentRepository>(relaxed = true)
+
+        val sut =
+            AttachmentWriterHelper(
+                attachmentRepository = attachmentRepository,
+            )
+
+        context("commit") {
+            val attachmentId = IdGenerator.getUUID()
+            val contestId = IdGenerator.getUUID()
+            val context = Attachment.Context.SUBMISSION_CODE
+
+            test("should throw NotFoundException when attachment is not found") {
+                every { attachmentRepository.findByIdAndContestId(attachmentId, contestId) } returns null
+
+                shouldThrow<NotFoundException> {
+                    sut.commit(
+                        attachmentId = attachmentId,
+                        contestId = contestId,
+                        context = context,
+                    )
+                }.message shouldBe "Attachment with id $attachmentId not found in contest with id $contestId"
+            }
+
+            test("should throw ForbiddenException when attachment is already commited") {
+                val attachment = AttachmentMockBuilder.build(isCommited = true)
+                every { attachmentRepository.findByIdAndContestId(attachmentId, contestId) } returns attachment
+
+                shouldThrow<ForbiddenException> {
+                    sut.commit(
+                        attachmentId = attachmentId,
+                        contestId = contestId,
+                        context = context,
+                    )
+                }.message shouldBe "Attachment with id $attachmentId is already commited"
+            }
+
+            test("should throw ForbiddenException when attachment has invalid context") {
+                val attachment = AttachmentMockBuilder.build(isCommited = false, context = Attachment.Context.PROBLEM_DESCRIPTION)
+                every { attachmentRepository.findByIdAndContestId(attachmentId, contestId) } returns attachment
+
+                shouldThrow<ForbiddenException> {
+                    sut.commit(
+                        attachmentId = attachmentId,
+                        contestId = contestId,
+                        context = context,
+                    )
+                }.message shouldBe "Attachment with id $attachmentId has invalid context ${attachment.context}"
+            }
+
+            test("should commit attachment successfully") {
+                val attachment = AttachmentMockBuilder.build(isCommited = false, context = context)
+                every { attachmentRepository.findByIdAndContestId(attachmentId, contestId) } returns attachment
+                every { attachmentRepository.save(any()) } returnsArgument 0
+
+                val result =
+                    sut.commit(
+                        attachmentId = attachmentId,
+                        contestId = contestId,
+                        context = context,
+                    )
+
+                result shouldBe attachment
+                result.isCommited shouldBe true
+                verify { attachmentRepository.save(result) }
+            }
+        }
+    })

--- a/applications/backend/core/src/test/kotlin/com/forsetijudge/core/application/service/external/contest/UpdateContestServiceTest.kt
+++ b/applications/backend/core/src/test/kotlin/com/forsetijudge/core/application/service/external/contest/UpdateContestServiceTest.kt
@@ -19,7 +19,6 @@ import com.forsetijudge.core.domain.exception.NotFoundException
 import com.forsetijudge.core.domain.model.ExecutionContext
 import com.forsetijudge.core.domain.model.ExecutionContextMockBuilder
 import com.forsetijudge.core.port.driven.cryptography.Hasher
-import com.forsetijudge.core.port.driven.repository.AttachmentRepository
 import com.forsetijudge.core.port.driven.repository.ContestRepository
 import com.forsetijudge.core.port.driven.repository.MemberRepository
 import com.forsetijudge.core.port.driven.repository.ProblemRepository

--- a/applications/backend/core/src/test/kotlin/com/forsetijudge/core/application/service/external/contest/UpdateContestServiceTest.kt
+++ b/applications/backend/core/src/test/kotlin/com/forsetijudge/core/application/service/external/contest/UpdateContestServiceTest.kt
@@ -1,5 +1,6 @@
 package com.forsetijudge.core.application.service.external.contest
 
+import com.forsetijudge.core.application.helper.AttachmentWriterHelper
 import com.forsetijudge.core.application.util.IdGenerator
 import com.forsetijudge.core.application.util.TestCasesValidator
 import com.forsetijudge.core.domain.entity.Attachment
@@ -37,23 +38,23 @@ import java.time.OffsetDateTime
 
 class UpdateContestServiceTest :
     FunSpec({
-        val attachmentRepository = mockk<AttachmentRepository>(relaxed = true)
         val contestRepository = mockk<ContestRepository>(relaxed = true)
         val problemRepository = mockk<ProblemRepository>(relaxed = true)
         val memberRepository = mockk<MemberRepository>(relaxed = true)
         val hasher = mockk<Hasher>(relaxed = true)
         val testCasesValidator = mockk<TestCasesValidator>(relaxed = true)
         val publishOutboxEventInternalUseCase = mockk<PublishOutboxEventInternalUseCase>(relaxed = true)
+        val attachmentWriterHelper = mockk<AttachmentWriterHelper>(relaxed = true)
 
         val sut =
             UpdateContestService(
-                attachmentRepository = attachmentRepository,
                 contestRepository = contestRepository,
                 problemRepository = problemRepository,
                 memberRepository = memberRepository,
                 hasher = hasher,
                 testCasesValidator = testCasesValidator,
                 publishOutboxEventInternalUseCase = publishOutboxEventInternalUseCase,
+                attachmentWriterHelper = attachmentWriterHelper,
             )
 
         val now = OffsetDateTime.now()
@@ -274,88 +275,6 @@ class UpdateContestServiceTest :
                 }
             }
 
-            test("should throw NotFoundException when problem description attachment does not exist") {
-                val contest =
-                    ContestMockBuilder.build(
-                        id = contextContestId,
-                        members = listOf(MemberMockBuilder.build(id = command.members[0].id!!)),
-                        problems = listOf(ProblemMockBuilder.build(id = command.problems[0].id!!)),
-                        endAt = now.plusHours(1),
-                    )
-                val member = MemberMockBuilder.build(type = Member.Type.ADMIN, contest = contest)
-                every { contestRepository.findById(contextContestId) } returns contest
-                every { memberRepository.findByIdAndContestIdOrContestIsNull(contextMemberId, contextContestId) } returns member
-                every { contestRepository.existsBySlugAndIdNot(command.slug, contextContestId) } returns false
-                every { attachmentRepository.findByIdAndContestId(command.problems[0].description.id, contextContestId) } returns null
-
-                shouldThrow<NotFoundException> {
-                    sut.execute(command)
-                }
-            }
-
-            test("should throw ForbiddenException when problem description attachment has wrong context") {
-                val contest =
-                    ContestMockBuilder.build(
-                        id = contextContestId,
-                        members = listOf(MemberMockBuilder.build(id = command.members[0].id!!)),
-                        problems = listOf(ProblemMockBuilder.build(id = command.problems[0].id!!)),
-                        endAt = now.plusHours(1),
-                    )
-                val descriptionAttachment = AttachmentMockBuilder.build(context = Attachment.Context.SUBMISSION_CODE)
-                val member = MemberMockBuilder.build(type = Member.Type.ADMIN, contest = contest)
-                every { contestRepository.findById(contextContestId) } returns contest
-                every { memberRepository.findByIdAndContestIdOrContestIsNull(contextMemberId, contextContestId) } returns member
-                every { contestRepository.existsBySlugAndIdNot(command.slug, contextContestId) } returns false
-                every { attachmentRepository.findByIdAndContestId(command.problems[0].description.id, contextContestId) } returns
-                    descriptionAttachment
-
-                shouldThrow<ForbiddenException> {
-                    sut.execute(command)
-                }
-            }
-
-            test("should throw NotFoundException when problem test cases attachment does not exist") {
-                val contest =
-                    ContestMockBuilder.build(
-                        id = contextContestId,
-                        members = listOf(MemberMockBuilder.build(id = command.members[0].id!!)),
-                        problems = listOf(ProblemMockBuilder.build(id = command.problems[0].id!!)),
-                        endAt = now.plusHours(1),
-                    )
-                val member = MemberMockBuilder.build(type = Member.Type.ADMIN, contest = contest)
-                every { contestRepository.findById(contextContestId) } returns contest
-                every { memberRepository.findByIdAndContestIdOrContestIsNull(contextMemberId, contextContestId) } returns member
-                every { contestRepository.existsBySlugAndIdNot(command.slug, contextContestId) } returns false
-                every { attachmentRepository.findByIdAndContestId(command.problems[0].description.id, contextContestId) } returns
-                    AttachmentMockBuilder.build(context = Attachment.Context.PROBLEM_DESCRIPTION)
-                every { attachmentRepository.findByIdAndContestId(command.problems[0].testCases.id, contextContestId) } returns null
-
-                shouldThrow<NotFoundException> {
-                    sut.execute(command)
-                }
-            }
-
-            test("should throw ForbiddenException when problem test cases attachment has wrong context") {
-                val contest =
-                    ContestMockBuilder.build(
-                        id = contextContestId,
-                        members = listOf(MemberMockBuilder.build(id = command.members[0].id!!)),
-                        problems = listOf(ProblemMockBuilder.build(id = command.problems[0].id!!)),
-                        endAt = now.plusHours(1),
-                    )
-                val testCasesAttachment = AttachmentMockBuilder.build(context = Attachment.Context.SUBMISSION_CODE)
-                every { contestRepository.findById(contextContestId) } returns contest
-                every { contestRepository.existsBySlugAndIdNot(command.slug, contextContestId) } returns false
-                every { attachmentRepository.findByIdAndContestId(command.problems[0].description.id, contextContestId) } returns
-                    AttachmentMockBuilder.build(context = Attachment.Context.PROBLEM_DESCRIPTION)
-                every { attachmentRepository.findByIdAndContestId(command.problems[0].testCases.id, contextContestId) } returns
-                    testCasesAttachment
-
-                shouldThrow<ForbiddenException> {
-                    sut.execute(command)
-                }
-            }
-
             test("should update contest successfully") {
                 val inputMemberToCreate = command.members[0].copy(id = null)
                 val inputProblemToCreate = command.problems[0].copy(id = null)
@@ -409,13 +328,37 @@ class UpdateContestServiceTest :
                         isCommited = false,
                     )
                 val testCasesAttachment = AttachmentMockBuilder.build(context = Attachment.Context.PROBLEM_TEST_CASES, isCommited = false)
-                every { attachmentRepository.findByIdAndContestId(inputProblemToCreate.description.id, contextContestId) } returns
+                every {
+                    attachmentWriterHelper.commit(
+                        inputProblemToCreate.description.id,
+                        contextContestId,
+                        Attachment.Context.PROBLEM_DESCRIPTION,
+                    )
+                } returns
                     descriptionAttachment
-                every { attachmentRepository.findByIdAndContestId(inputProblemToCreate.testCases.id, contextContestId) } returns
+                every {
+                    attachmentWriterHelper.commit(
+                        inputProblemToCreate.testCases.id,
+                        contextContestId,
+                        Attachment.Context.PROBLEM_TEST_CASES,
+                    )
+                } returns
                     testCasesAttachment
-                every { attachmentRepository.findByIdAndContestId(inputProblemToUpdateFull.description.id, contextContestId) } returns
+                every {
+                    attachmentWriterHelper.commit(
+                        inputProblemToUpdateFull.description.id,
+                        contextContestId,
+                        Attachment.Context.PROBLEM_DESCRIPTION,
+                    )
+                } returns
                     descriptionAttachment
-                every { attachmentRepository.findByIdAndContestId(inputProblemToUpdateFull.testCases.id, contextContestId) } returns
+                every {
+                    attachmentWriterHelper.commit(
+                        inputProblemToUpdateFull.testCases.id,
+                        contextContestId,
+                        Attachment.Context.PROBLEM_TEST_CASES,
+                    )
+                } returns
                     testCasesAttachment
                 every { contestRepository.save(any<Contest>()) } answers { firstArg() }
 
@@ -456,21 +399,17 @@ class UpdateContestServiceTest :
                 contest.problems[1].color shouldBe inputProblemToUpdateMinimum.color.lowercase()
                 contest.problems[1].title shouldBe inputProblemToUpdateMinimum.title
                 contest.problems[1].description shouldBe problemToUpdateMinimum.description
-                contest.problems[1].description.isCommited shouldBe true
                 contest.problems[1].timeLimit shouldBe problemToUpdateMinimum.timeLimit
                 contest.problems[1].memoryLimit shouldBe problemToUpdateMinimum.memoryLimit
                 contest.problems[1].testCases shouldBe problemToUpdateMinimum.testCases
-                contest.problems[1].testCases.isCommited shouldBe true
                 contest.problems[2].id shouldBe inputProblemToUpdateFull.id
                 contest.problems[2].letter shouldBe inputProblemToUpdateFull.letter
                 contest.problems[2].color shouldBe inputProblemToUpdateFull.color.lowercase()
                 contest.problems[2].title shouldBe inputProblemToUpdateFull.title
                 contest.problems[2].description shouldBe descriptionAttachment
-                contest.problems[2].description.isCommited shouldBe true
                 contest.problems[2].timeLimit shouldBe inputProblemToUpdateFull.timeLimit
                 contest.problems[2].memoryLimit shouldBe inputProblemToUpdateFull.memoryLimit
                 contest.problems[2].testCases shouldBe testCasesAttachment
-                contest.problems[2].testCases.isCommited shouldBe true
 
                 problemToDelete.description.isCommited shouldBe false
                 problemToDelete.testCases.isCommited shouldBe false

--- a/applications/backend/core/src/test/kotlin/com/forsetijudge/core/application/service/external/submission/CreateSubmissionExternalServiceTest.kt
+++ b/applications/backend/core/src/test/kotlin/com/forsetijudge/core/application/service/external/submission/CreateSubmissionExternalServiceTest.kt
@@ -14,7 +14,6 @@ import com.forsetijudge.core.domain.exception.ForbiddenException
 import com.forsetijudge.core.domain.exception.NotFoundException
 import com.forsetijudge.core.domain.model.ExecutionContext
 import com.forsetijudge.core.domain.model.ExecutionContextMockBuilder
-import com.forsetijudge.core.port.driven.repository.AttachmentRepository
 import com.forsetijudge.core.port.driven.repository.ContestRepository
 import com.forsetijudge.core.port.driven.repository.FrozenSubmissionRepository
 import com.forsetijudge.core.port.driven.repository.MemberRepository

--- a/applications/backend/core/src/test/kotlin/com/forsetijudge/core/application/service/external/submission/CreateSubmissionExternalServiceTest.kt
+++ b/applications/backend/core/src/test/kotlin/com/forsetijudge/core/application/service/external/submission/CreateSubmissionExternalServiceTest.kt
@@ -1,5 +1,6 @@
 package com.forsetijudge.core.application.service.external.submission
 
+import com.forsetijudge.core.application.helper.AttachmentWriterHelper
 import com.forsetijudge.core.application.util.IdGenerator
 import com.forsetijudge.core.domain.entity.Attachment
 import com.forsetijudge.core.domain.entity.AttachmentMockBuilder
@@ -34,23 +35,23 @@ import io.mockk.verify
 
 class CreateSubmissionExternalServiceTest :
     FunSpec({
-        val attachmentRepository = mockk<AttachmentRepository>(relaxed = true)
         val contestRepository = mockk<ContestRepository>(relaxed = true)
         val memberRepository = mockk<MemberRepository>(relaxed = true)
         val problemRepository = mockk<ProblemRepository>(relaxed = true)
         val submissionRepository = mockk<SubmissionRepository>(relaxed = true)
         val frozenSubmissionRepository = mockk<FrozenSubmissionRepository>(relaxed = true)
         val publishOutboxEventInternalUseCase = mockk<PublishOutboxEventInternalUseCase>(relaxed = true)
+        val attachmentWriterHelper = mockk<AttachmentWriterHelper>(relaxed = true)
 
         val sut =
             CreateSubmissionService(
-                attachmentRepository = attachmentRepository,
                 contestRepository = contestRepository,
                 memberRepository = memberRepository,
                 problemRepository = problemRepository,
                 submissionRepository = submissionRepository,
                 frozenSubmissionRepository = frozenSubmissionRepository,
                 publishOutboxEventInternalUseCase = publishOutboxEventInternalUseCase,
+                attachmentWriterHelper = attachmentWriterHelper,
             )
 
         val contextContestId = IdGenerator.getUUID()
@@ -131,39 +132,6 @@ class CreateSubmissionExternalServiceTest :
             shouldThrow<NotFoundException> { sut.execute(command) }
         }
 
-        test("should throw NotFoundException when code does not exist") {
-            val contest =
-                ContestMockBuilder.build(
-                    startAt = ExecutionContext.get().startedAt.minusHours(1),
-                    endAt = ExecutionContext.get().startedAt.plusHours(2),
-                )
-            val member = MemberMockBuilder.build(type = Member.Type.CONTESTANT, contest = contest)
-            val problem = ProblemMockBuilder.build()
-            every { contestRepository.findById(any()) } returns contest
-            every { memberRepository.findByIdAndContestIdOrContestIsNull(any(), any()) } returns member
-            every { problemRepository.findByIdAndContestId(command.problemId, contextContestId) } returns problem
-            every { attachmentRepository.findByIdAndContestId(command.code.id, contextContestId) } returns null
-
-            shouldThrow<NotFoundException> { sut.execute(command) }
-        }
-
-        test("should throw ForbiddenException when code context is not SUBMISSION_CODE") {
-            val contest =
-                ContestMockBuilder.build(
-                    startAt = ExecutionContext.get().startedAt.minusHours(1),
-                    endAt = ExecutionContext.get().startedAt.plusHours(2),
-                )
-            val member = MemberMockBuilder.build(type = Member.Type.CONTESTANT, contest = contest)
-            val problem = ProblemMockBuilder.build()
-            val code = AttachmentMockBuilder.build(context = Attachment.Context.PROBLEM_DESCRIPTION)
-            every { contestRepository.findById(any()) } returns contest
-            every { memberRepository.findByIdAndContestIdOrContestIsNull(any(), any()) } returns member
-            every { problemRepository.findByIdAndContestId(command.problemId, contextContestId) } returns problem
-            every { attachmentRepository.findByIdAndContestId(command.code.id, contextContestId) } returns code
-
-            shouldThrow<ForbiddenException> { sut.execute(command) }
-        }
-
         test("should create submission successfully") {
             val contest =
                 ContestMockBuilder.build(
@@ -176,7 +144,7 @@ class CreateSubmissionExternalServiceTest :
             every { contestRepository.findById(any()) } returns contest
             every { memberRepository.findByIdAndContestIdOrContestIsNull(any(), any()) } returns member
             every { problemRepository.findByIdAndContestId(command.problemId, contextContestId) } returns problem
-            every { attachmentRepository.findByIdAndContestId(command.code.id, contextContestId) } returns code
+            every { attachmentWriterHelper.commit(command.code.id, contextContestId, Attachment.Context.SUBMISSION_CODE) } returns code
             every { submissionRepository.save(any()) } answers { firstArg() }
             every { frozenSubmissionRepository.save(any()) } answers { firstArg() }
 
@@ -191,7 +159,6 @@ class CreateSubmissionExternalServiceTest :
             submission.status shouldBe Submission.Status.JUDGING
             submission.answer shouldBe null
             submission.code shouldBe code
-            submission.code.isCommited shouldBe true
             result shouldBe submission.toWithCodeResponseBodyDTO()
             verify { frozenSubmissionRepository.save(any()) }
             verify {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes introduced by this PR -->

A user can create a submission with another user code if it has the attachment_id. This PR limits attachment commit for items that are not commited.

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Related Issues

<!-- Link any related issues using GitHub keywords -->
<!-- Examples:
- Closes #123
- Fixes #456
- Resolves #789
- Related to #101
-->

Closes #220 

## Additional Notes

<!-- Add any additional notes, concerns, or context for the reviewers -->
